### PR TITLE
Update logging, DB client and ignoring bot own comment

### DIFF
--- a/app/dao.py
+++ b/app/dao.py
@@ -3,29 +3,29 @@ from app.psql.Psql import Psql
 
 def fetch_comments(psql: Psql):
     sql = "SELECT * FROM comments"
-    
-    return psql.fetchall(sql)
+
+    return psql.execute(sql, fetchall=True)
+
+
+def fetch_responses(psql: Psql):
+    sql = "SELECT * FROM responses"
+
+    return psql.execute(sql, fetchall=True)
+
+
+def fetch_vocatives(psql: Psql):
+    sql = "SELECT * FROM vocatives"
+
+    return psql.execute(sql, fetchall=True)
 
 
 def insert_comments(psql: Psql, comments: list):
     sql = "INSERT INTO comments VALUES %s"
 
     return psql.execute_many(sql, params=comments)
-    
+
 
 def delete_old_comments(psql: Psql, comments: tuple):
     sql = "DELETE FROM comments WHERE comment NOT IN %s"
 
     return psql.execute(sql, params=comments)
-
-
-def fetch_responses(psql: Psql):
-    sql = "SELECT * FROM responses"
-    
-    return psql.fetchall(sql)
-
-
-def fetch_vocatives(psql: Psql):
-    sql = "SELECT * FROM vocatives"
-    
-    return psql.fetchall(sql)

--- a/app/psql/Psql.py
+++ b/app/psql/Psql.py
@@ -13,13 +13,9 @@ class Psql:
             try:
                 print("Connecting to PostgreSQL database...")
                 connection = Psql._instance.connection = psycopg2.connect(DATABASE_URL)
-                cursor = Psql._instance.cursor = connection.cursor()
-                cursor.execute("SELECT VERSION()")
-                db_version = cursor.fetchone()
+                Psql._instance.cursor = connection.cursor()
             except Exception as error:
                 print(f"Error: connection not established\n{error}")
-            else:
-                print("Success: connection established\n{}".format(db_version[0]))
             
             return cls._instance
 
@@ -29,19 +25,9 @@ class Psql:
 
     def __del__(self):
         self.cursor.close()
-        self.connection.close()
-
-    def fetchall(self, sql, params=tuple()):
-        try:
-            self.cursor.execute(sql, (params,))
-        except Exception as error:
-            print('error execting query "{}", error: {}'.format(sql, error))
-            return None
-        else:
-            return self.cursor.fetchall()
-            
+        self.connection.close()            
     
-    def execute(self, sql, params=tuple()):
+    def execute(self, sql, params=tuple(), fetchall=False):
         try:
             self.cursor.execute(sql, (params,))
         except Exception as error:
@@ -49,8 +35,11 @@ class Psql:
             print('error execting query "{}", error: {}'.format(sql, error))
             return None
         else:
-            self.connection.commit()
-            return self.cursor.statusmessage
+            if fetchall:
+                return self.cursor.fetchall()
+            else:
+                self.connection.commit()
+                return self.cursor.statusmessage
 
     def execute_many(self, sql, params=tuple()):
         try:

--- a/app/reply/ReplyBase.py
+++ b/app/reply/ReplyBase.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 from app.dao import delete_old_comments, fetch_comments, insert_comments
 from app.psql.Psql import Psql
+from app.config import USERNAME
 
 
 class ReplyBase(ABC):
@@ -18,36 +19,38 @@ class ReplyBase(ABC):
         for submission in self._subreddit.new(limit=self._limit):
             for comment in submission.comments.list():
 
+                if comment.author.name == USERNAME:
+                    continue
+
                 if comment.id in stored_comments:
                     new_comments[comment.id] = False
                     continue
 
-                print(f"Username: {comment.author.name}")
-                print(f"Comment preview: {comment.body[:50]}")
+                print(f"URL: https://www.reddit.com{comment.permalink}")
                 self._reply(comment)
 
                 new_comments[comment.id] = True
-                
+
         self._delete_old_comments(new_comments)
         self._insert_comments(new_comments)
-    
+
     @abstractmethod
     def _reply(self, comment):
         pass
-    
+
     def _fetch_comments(self):
         print("Fetching Comments' IDs from DB")
         result = fetch_comments(self._psql)
         if result is None:
             return list()
-        
+
         return [comment[0] for comment in result]
-    
+
     def _delete_old_comments(self, new):
         result = delete_old_comments(self._psql, tuple(new.keys()))
         if not result:
-            print(f"Deleted old Comments' IDs status message: {result}")
-  
+            print(f"Delete old Comments' IDs status message: {result}")
+
     def _insert_comments(self, comments):
         param = [(id_,) for id_, new in comments.items() if new]
         if param:

--- a/app/reply/ReplyToLowercase.py
+++ b/app/reply/ReplyToLowercase.py
@@ -23,11 +23,9 @@ class ReplyToLowercase(ReplyBase):
     def _reply(self, comment):
         processed_body = self._parse_comment(comment.body)
         if not self._is_uppercase(processed_body):
-            print("Replying...")
+            print(f"Replying to {comment.author.name}...")
             message = self._get_random_message()
             comment.reply(message)
-        else:
-            print("OK")
 
     def _parse_comment(self, text: str):
         """Remove words that are allowed to be lowercase


### PR DESCRIPTION
Better logging: Now when reading comments printing only url to said comment and a 'replying' message if replying.
DB Client: Removes Psql.fetchall method, now using a parameter in Psql.execute when needing to fetchall.
Ignoring bot own comment: Preventing recursion by making the bot unable to reply to itself.
